### PR TITLE
Default bearer description edited

### DIFF
--- a/src/SwaggerExtension/SwaggerExtension/Infrastructure/SwaggerConstants.cs
+++ b/src/SwaggerExtension/SwaggerExtension/Infrastructure/SwaggerConstants.cs
@@ -12,6 +12,5 @@ internal class SwaggerConstants
 
     internal const string BearerFormat = "JWT";
     internal const string BearerHeaderKey = "bearer";
-    internal static string DefaultBearerDescription
-        => "JWT Authorization header using the {HeaderKey} scheme. \r\n\r\n Enter '{HeaderKey}' [space] and then your token in the text input below.\r\n\r\nExample: \"{HeaderKey} {TOKEN}\"".Replace("{HeaderKey}", BearerHeaderKey);
+    internal static string DefaultBearerDescription => $"JWT Authorization header using the {BearerHeaderKey} scheme. \r\n\r\n Enter your {BearerHeaderKey} token in the text input below.";
 }


### PR DESCRIPTION
According to the description, when authorized, the bearer key was being sent twice.